### PR TITLE
making the navbar fixed

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -19,7 +19,7 @@ body {
   height: var(--navbar-height);
 }
 
-nav {
+nav.topnav {
   position: fixed;
   width: 100vw;
   top: 0px;

--- a/src/global.css
+++ b/src/global.css
@@ -19,6 +19,16 @@ body {
   height: var(--navbar-height);
 }
 
+nav {
+  position: fixed;
+  width: 100vw;
+  top: 0px;
+}
+
+.m-t-navBarHeight {
+  margin-top: var(--navBarHeight);
+}
+
 .brand-button {
   background-color: var(--orange);
   color: var(--white);

--- a/src/global.css
+++ b/src/global.css
@@ -26,7 +26,7 @@ nav {
 }
 
 .m-t-navBarHeight {
-  margin-top: var(--navBarHeight);
+  margin-top: var(--navbar-height);
 }
 
 .brand-button {

--- a/src/global.css
+++ b/src/global.css
@@ -23,6 +23,7 @@ nav {
   position: fixed;
   width: 100vw;
   top: 0px;
+  z-index: 100;
 }
 
 .m-t-navBarHeight {


### PR DESCRIPTION
Fixes this behavior, which can happen in rare race conditions: 

![Screen Shot 2020-03-19 at 2 15 16 PM](https://user-images.githubusercontent.com/3059715/77114344-fb28a080-69f1-11ea-955c-9cf513e89d3e.png)

The following PRs need to be merged to add margin to the top to prevent them being covered up:
- https://github.com/react-microfrontends/people/pull/4
- https://github.com/react-microfrontends/planets/pull/4
- https://github.com/react-microfrontends/navbar/pull/7